### PR TITLE
use busybox:1.28 for init containers demo

### DIFF
--- a/app/simple_app/init-container-demo.yaml
+++ b/app/simple_app/init-container-demo.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod
+  labels:
+    app: myapp
+spec:
+  containers:
+  - name: myapp-container
+    image: busybox:1.28
+    command: ['sh', '-c', 'echo The app is running! && sleep 3600']
+  initContainers:
+  - name: init-myservice
+    image: busybox:1.28
+    command: ['sh', '-c', 'until nslookup myservice; do echo waiting for myservice; sleep 2; done;']
+  - name: init-mydb
+    image: busybox:1.28
+    command: ['sh', '-c', 'until nslookup mydb; do echo waiting for mydb; sleep 2; done;']


### PR DESCRIPTION
According to https://github.com/docker-library/busybox/issues/48, latest busybox images wont give expected results for demo purposes. Instead `busybox:1.28` provides apt behavior for this demo. To make the latest busybox image work as expected, use nslookup command like `nslookup -type=a mydb.default.svc.cluster.local`. However this command breaks the `until` loop immediately hence needs some modification.